### PR TITLE
Implement new tab override feature (fix #31)

### DIFF
--- a/chrome-extension/manifest.js
+++ b/chrome-extension/manifest.js
@@ -38,9 +38,6 @@ const manifest = {
   action: {
     default_icon: 'icon-34.png',
   },
-  chrome_url_overrides: {
-    newtab: 'new-tab/index.html',
-  },
   host_permissions: ['https://*.atlassian.net/'],
   icons: {
     128: 'icon-128.png',

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -16,9 +16,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "webextension-polyfill": "^0.12.0",
     "@extension/shared": "workspace:*",
-    "@extension/storage": "workspace:*"
+    "@extension/storage": "workspace:*",
+    "@plasmohq/storage": "^1.12.0",
+    "webextension-polyfill": "^0.12.0"
   },
   "devDependencies": {
     "@extension/dev-utils": "workspace:*",
@@ -27,9 +28,9 @@
     "@extension/vite-config": "workspace:*",
     "@laynezh/vite-plugin-lib-assets": "^0.5.23",
     "@types/ws": "^8.5.12",
-    "magic-string": "^0.30.10",
-    "ts-loader": "^9.5.1",
+    "cross-env": "^7.0.3",
     "deepmerge": "^4.3.1",
-    "cross-env": "^7.0.3"
+    "magic-string": "^0.30.10",
+    "ts-loader": "^9.5.1"
   }
 }

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -1,5 +1,7 @@
 import 'webextension-polyfill';
 
+import './set-newtab-override';
+
 chrome.action.onClicked.addListener(() => {
   chrome.tabs.create({ url: chrome.runtime.getURL('new-tab/index.html') });
 });

--- a/chrome-extension/src/background/set-newtab-override.ts
+++ b/chrome-extension/src/background/set-newtab-override.ts
@@ -1,0 +1,38 @@
+import { Storage } from '@plasmohq/storage';
+
+const storage = new Storage();
+
+const NEW_TAB_URL = 'chrome://newtab/';
+const KEY_OVERRIDE_NEW_TAB = 'overrideNewTab';
+
+const handleTabCreated = (tab: chrome.tabs.Tab) => {
+  if (tab.pendingUrl === NEW_TAB_URL || tab.url === NEW_TAB_URL) {
+    if (tab.id) {
+      chrome.tabs.update(tab.id, { url: chrome.runtime.getURL('new-tab/index.html') });
+    }
+  }
+};
+
+const handleOverrideNewTab = (isOverride: boolean) => {
+  if (isOverride) {
+    chrome.tabs.onCreated.addListener(handleTabCreated);
+  } else {
+    chrome.tabs.onCreated.removeListener(handleTabCreated);
+  }
+};
+
+chrome.runtime.onInstalled.addListener(async () => {
+  const overrideNewTab = await storage.get(KEY_OVERRIDE_NEW_TAB);
+  if (overrideNewTab === undefined) {
+    await storage.set(KEY_OVERRIDE_NEW_TAB, true);
+  }
+});
+
+chrome.runtime.onMessage.addListener(async message => {
+  if (message.type === 'UPDATE_NEW_TAB_OVERRIDE') {
+    await storage.set(KEY_OVERRIDE_NEW_TAB, message.value);
+    handleOverrideNewTab(message.value);
+  }
+});
+
+storage.get(KEY_OVERRIDE_NEW_TAB).then(handleOverrideNewTab);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@extension/storage':
         specifier: workspace:*
         version: link:../packages/storage
+      '@plasmohq/storage':
+        specifier: ^1.12.0
+        version: 1.12.0(react@18.3.1)
       webextension-polyfill:
         specifier: ^0.12.0
         version: 0.12.0
@@ -1827,6 +1830,14 @@ packages:
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@plasmohq/storage@1.12.0':
+    resolution: {integrity: sha512-LoCyO0PXl609ee8QKVEwVpkTyD/8WjYQhd0sxFomLxbdxsZC0LD4n8nv4nSegP5X8lYQBQnR/LMq4ZXoQh87wA==}
+    peerDependencies:
+      react: ^16.8.6 || ^17 || ^18
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
@@ -4294,6 +4305,10 @@ packages:
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
+
+  pify@6.1.0:
+    resolution: {integrity: sha512-KocF8ve28eFjjuBKKGvzOBGzG8ew2OqOOSxTTZhirkzH7h3BI1vyzqlR0qbfcDBve1Yzo3FVlWUAtCRrbVN8Fw==}
+    engines: {node: '>=14.16'}
 
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
@@ -7092,6 +7107,12 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.1.1': {}
+
+  '@plasmohq/storage@1.12.0(react@18.3.1)':
+    dependencies:
+      pify: 6.1.0
+    optionalDependencies:
+      react: 18.3.1
 
   '@popperjs/core@2.11.8': {}
 
@@ -9959,6 +9980,8 @@ snapshots:
   pidtree@0.6.0: {}
 
   pify@2.3.0: {}
+
+  pify@6.1.0: {}
 
   pirates@4.0.6: {}
 


### PR DESCRIPTION
Add functionality to override the default new tab page.

- Removed old new tab override from manifest.
- Added new file to handle new tab redirection.
- Updated settings view to include toggle for new tab override.

